### PR TITLE
Suppress spurious warnings.

### DIFF
--- a/lib/Search/Indexer.pm
+++ b/lib/Search/Indexer.pm
@@ -2,7 +2,8 @@ package Search::Indexer;
 
 use strict;
 use warnings; 
-# no warnings 'uninitialized'; ## CHECK IF NEEDED OR NOT
+no warnings 'uninitialized';
+
 use Carp;
 use BerkeleyDB;
 use locale;


### PR DESCRIPTION
Salut Laurent,
C'est pour éviter des tonnes de warnings dans les logs, à la recherche, sur certains index.
Merci,
Richard
